### PR TITLE
Fix wasm loading for woff2 conversion

### DIFF
--- a/src/app/shared/fonts.ts
+++ b/src/app/shared/fonts.ts
@@ -3,6 +3,8 @@ import svg2ttf from 'svg2ttf';
 import ttf2eot from 'ttf2eot';
 import ttf2woff from 'ttf2woff';
 import ttf2woff2 from 'ttf2woff2';
+import wasmUrl from 'ttf2woff2/jssrc/ttf2woff2.wasm';
+(ttf2woff2 as any).locateFile = () => wasmUrl;
 import cheerio from 'cheerio';
 import JSZip from 'jszip';
 

--- a/src/wasm.d.ts
+++ b/src/wasm.d.ts
@@ -1,0 +1,4 @@
+declare module '*.wasm' {
+  const value: string;
+  export default value;
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,11 +27,15 @@ module.exports = (env, argv) => ({
         ],
       },
       { test: /\.(png|jpg|gif|webp|svg)$/, loader: 'url-loader' },
+      { test: /\.wasm$/, type: 'asset/resource' },
       {
         test: /\.node$/,
         use: 'node-loader'
       }
     ],
+  },
+  experiments: {
+    asyncWebAssembly: true,
   },
   resolve: {
     extensions: ['.tsx', '.ts', '.jsx', '.js'],


### PR DESCRIPTION
## Summary
- load `ttf2woff2` WASM asset explicitly
- handle `.wasm` files in webpack config
- declare module for `.wasm` imports

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844adf58dd88325811615f80ad40250