### PR TITLE
Add checks for missing SVG files

### DIFF
--- a/src/app/components/App.tsx
+++ b/src/app/components/App.tsx
@@ -114,16 +114,19 @@ const App = (): ReactElement => {
   };
 
   const inputFileUpload = (files): void => {
-    if (files) {
+    if (files && files.length > 0) {
       setLoadingUpload(true);
-    }
 
-    void generateVetores(files[0], (vectors) => {
-      parent.postMessage(
-        { pluginMessage: { type: 'createFigmaVetors', vectors } },
-        '*',
-      );
-    });
+      void generateVetores(files[0], (vectors) => {
+        parent.postMessage(
+          { pluginMessage: { type: 'createFigmaVetors', vectors } },
+          '*',
+        );
+      });
+    } else {
+      setErrors('No SVG file selected');
+      setOpenSnack(true);
+    }
   };
 
   useEffect(() => {
@@ -144,6 +147,13 @@ const App = (): ReactElement => {
 
       const events = {
         downloadFonts: () => {
+          if (!files || files.length === 0) {
+            setErrors('No icons selected');
+            setOpenSnack(true);
+            setLoadingGenerate(false);
+            return;
+          }
+
           generateFonts(
             files,
             fontsConfig,
@@ -179,6 +189,13 @@ const App = (): ReactElement => {
           );
         },
         commitGithub: () => {
+          if (!files || files.length === 0) {
+            setErrors('No icons selected');
+            setOpenSnack(true);
+            setLoadingGenerate(false);
+            return;
+          }
+
           generateFonts(
             files,
             fontsConfig,
@@ -215,11 +232,11 @@ const App = (): ReactElement => {
           );
         },
         setSvgs: () => {
-          if (files.length) {
+          if (files && files.length > 0) {
             generateFonts(files, fontsConfig, hasLigatura, false, callback);
             return;
           }
-          setIcons(files);
+          setIcons(files || []);
         },
         setRootFontConfg: () => {
           setFontConfig(files);

--- a/src/app/shared/fonts.ts
+++ b/src/app/shared/fonts.ts
@@ -1,4 +1,7 @@
-import { SVGIcons2SVGFontStream, SVGIcons2SVGFontStreamOptions } from 'svgicons2svgfont';
+import {
+  SVGIcons2SVGFontStream,
+  SVGIcons2SVGFontStreamOptions,
+} from 'svgicons2svgfont';
 import svg2ttf from 'svg2ttf';
 import ttf2eot from 'ttf2eot';
 import ttf2woff from 'ttf2woff';
@@ -43,11 +46,15 @@ export const generateFonts = (
   gitHubData?: IFormGithub,
 ): void => {
   try {
+    if (!Array.isArray(files) || files.length === 0) {
+      callback?.(new Error('No SVG files provided'));
+      return;
+    }
     const fontStream = new SVGIcons2SVGFontStream(optons);
     const decoder = new StringDecoder('utf8');
     const parts: string[] = [];
     const urls: IFontFormats = {};
-    
+
     const json = iconConfigs(files, hasLigatura);
     const { iconStreams, _zip } = iconsStrems(json, download);
 


### PR DESCRIPTION
## Summary
- guard against missing files in `generateFonts`
- show an error when no file is uploaded
- check for files before generating fonts from plugin events

## Testing
- `yarn eslint` *(fails: ESLint couldn't find a config)*
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_685c73bbb7b88325b2f94b84fe2c8fa4