### PR TITLE
Refactor shared utilities and UI components

### DIFF
--- a/shared/fontHelpers.ts
+++ b/shared/fontHelpers.ts
@@ -1,0 +1,147 @@
+import JSZip from 'jszip';
+import { load } from 'cheerio';
+import { PassThrough } from 'stream';
+import { verifySingleString } from './utils';
+import { IJsonType, ISerializedSVG } from './typings';
+
+export const iconConfigs = (files: ISerializedSVG[], hasLigatura: boolean) => {
+  let json: IJsonType[] = [];
+  let namesControl: string[] = [];
+  let ligasControl: string[] = [];
+  let unicodesExisting: string[] = [];
+
+  files.forEach((file: ISerializedSVG) => {
+    let matches: string[];
+
+    const blob = new Blob([file.svg], { type: 'image/svg+xml' });
+    const svg = new File([blob], `${file.name}.svg`, {
+      type: 'image/svg+xml',
+    });
+
+    if (!svg.name.includes('--')) {
+      matches = svg.name.match(
+        /^(?:((?:u[0-9a-f]{4,6},?)+)-)?(.+)\.svg$/i,
+      ) as string[];
+    } else {
+      matches = svg.name.match(
+        /^(?:((?:u[0-9a-f]{4,6},?)+)-)?(?:(.+)--)?(.+)\.svg$/i,
+      ) as string[];
+    }
+
+    const matcheName = verifySingleString(matches[2], namesControl);
+    namesControl = [...namesControl, matcheName];
+
+    const ligature = hasLigatura
+      ? matches?.[3]
+        ? matches[3].split(',')
+        : [matcheName.replace(/ /g, '-')]
+      : [];
+
+    ligature.forEach((liga, index) => {
+      const repeatLiga = verifySingleString(liga, ligasControl);
+
+      if (repeatLiga !== liga) {
+        ligature[index] = repeatLiga;
+      }
+    });
+
+    ligasControl = [...ligasControl, ...ligature];
+
+    if (matches?.[1]) {
+      matches[1].split(',').filter((element) => {
+        if (unicodesExisting.includes(element)) {
+          throw new Error(`Duplicate unicode - ${element}`);
+        }
+      });
+
+      unicodesExisting = [...unicodesExisting, ...matches[1].split(',')];
+    }
+
+    json.push({
+      id: file.id,
+      svg: file.svg,
+      svgFile: svg,
+      name: matches?.[2] ? matcheName : file.name,
+      ligature,
+      unicode: matches?.[1] ? matches[1].split(',') : '',
+    });
+  });
+
+  json = json.map((icon) => {
+    if (!icon.unicode) {
+      for (let i = 0; i < json.length; i++) {
+        const curCodepoint = `u${(parseInt('e900', 16) + i).toString(16)}`;
+        if (!unicodesExisting.includes(curCodepoint)) {
+          unicodesExisting.push(curCodepoint);
+          icon.unicode = [curCodepoint];
+          break;
+        }
+        continue;
+      }
+
+      return icon;
+    }
+
+    return icon;
+  });
+
+  return json;
+};
+
+export const iconsStrems = (json: IJsonType[], download?: boolean) => {
+  const _zip = new JSZip();
+
+  const iconStreams = json.map((icon: IJsonType) => {
+    const iconStream: PassThrough & {
+      metadata?: { unicode: string[]; name: string };
+    } = new PassThrough();
+
+    const reader = new FileReader();
+
+    if (download) {
+      const svgs = _zip.folder('svg');
+      svgs?.file(`${icon.name}.svg`, icon.svgFile);
+    }
+
+    reader.onload = (e) => {
+      iconStream.write(e.target?.result);
+      iconStream.end();
+    };
+    reader.readAsText(icon.svgFile);
+
+    const unicode = Array.isArray(icon.unicode)
+      ? icon.unicode.map((curCodepoint) =>
+          String.fromCharCode(parseInt(curCodepoint.replace('u', '0x'), 16)),
+        )
+      : [String.fromCharCode(parseInt(icon.unicode.replace('u', '0x')))] ;
+
+    iconStream.metadata = {
+      unicode: [...unicode, ...icon.ligature],
+      name: icon.name,
+    };
+
+    return iconStream;
+  });
+
+  return {
+    iconStreams,
+    _zip,
+  };
+};
+
+export const createSvgSymbol = (files: ISerializedSVG[]): string => {
+  const $ = load(
+    '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0" style="display:none;"></svg>',
+    { xmlMode: true },
+  );
+  files.forEach((file: ISerializedSVG) => {
+    const svgNode = $(file.svg);
+    const symbolNode = $('<symbol></symbol>');
+    symbolNode.attr('viewBox', svgNode.attr('viewBox'));
+    symbolNode.attr('id', file.name);
+    symbolNode.append(svgNode.html());
+    $('svg').append(symbolNode);
+  });
+
+  return $.html('svg');
+};

--- a/shared/fonts.ts
+++ b/shared/fonts.ts
@@ -1,25 +1,21 @@
-import JSZip from 'jszip';
 import svg2ttf from 'svg2ttf';
 import ttf2eot from 'ttf2eot';
-import { load } from 'cheerio';
 import ttf2woff from 'ttf2woff';
 import ttf2woff2 from 'ttf2woff2';
 import { saveAs } from 'file-saver';
-import { PassThrough } from 'stream';
 import { StringDecoder } from 'string_decoder';
 import {
   SVGIcons2SVGFontStream,
   SVGIcons2SVGFontStreamOptions,
 } from 'svgicons2svgfont';
-import { verifySingleString } from './utils';
 import { commitFileAndOpenPR } from './github';
 import {
   IFontFormats,
   IFormGithub,
   IGeneratedFont,
-  IJsonType,
   ISerializedSVG,
 } from './typings';
+import { iconConfigs, iconsStrems, createSvgSymbol } from './fontHelpers';
 
 export const generateFonts = (
   files: ISerializedSVG[],
@@ -146,144 +142,3 @@ export const generateFonts = (
   }
 };
 
-export const iconConfigs = (files: ISerializedSVG[], hasLigatura: boolean) => {
-  let json: IJsonType[] = [];
-  let namesControl: string[] = [];
-  let ligasControl: string[] = [];
-  let unicodesExisting: string[] = [];
-
-  files.forEach((file: ISerializedSVG) => {
-    let matches: string[];
-
-    const blob = new Blob([file.svg], { type: 'image/svg+xml' });
-    const svg = new File([blob], `${file.name}.svg`, {
-      type: 'image/svg+xml',
-    });
-
-    if (!svg.name.includes('--')) {
-      matches = svg.name.match(
-        /^(?:((?:u[0-9a-f]{4,6},?)+)-)?(.+)\.svg$/i,
-      ) as string[];
-    } else {
-      matches = svg.name.match(
-        /^(?:((?:u[0-9a-f]{4,6},?)+)-)?(?:(.+)--)?(.+)\.svg$/i,
-      ) as string[];
-    }
-
-    const matcheName = verifySingleString(matches[2], namesControl);
-    namesControl = [...namesControl, matcheName];
-
-    const ligature = hasLigatura
-      ? matches?.[3]
-        ? matches[3].split(',')
-        : [matcheName.replace(/ /g, '-')]
-      : [];
-
-    ligature.forEach((liga, index) => {
-      const repeatLiga = verifySingleString(liga, ligasControl);
-
-      if (repeatLiga !== liga) {
-        ligature[index] = repeatLiga;
-      }
-    });
-
-    ligasControl = [...ligasControl, ...ligature];
-
-    if (matches?.[1]) {
-      matches[1].split(',').filter((element) => {
-        if (unicodesExisting.includes(element)) {
-          throw new Error(`Duplicate unicode - ${element}`);
-        }
-      });
-
-      unicodesExisting = [...unicodesExisting, ...matches[1].split(',')];
-    }
-
-    json.push({
-      id: file.id,
-      svg: file.svg,
-      svgFile: svg,
-      name: matches?.[2] ? matcheName : file.name,
-      ligature,
-      unicode: matches?.[1] ? matches[1].split(',') : '',
-    });
-  });
-
-  json = json.map((icon) => {
-    if (!icon.unicode) {
-      for (let i = 0; i < json.length; i++) {
-        const curCodepoint = `u${(parseInt('e900', 16) + i).toString(16)}`;
-        if (!unicodesExisting.includes(curCodepoint)) {
-          unicodesExisting.push(curCodepoint);
-          icon.unicode = [curCodepoint];
-          break;
-        }
-        continue;
-      }
-
-      return icon;
-    }
-
-    return icon;
-  });
-
-  return json;
-};
-
-export const iconsStrems = (json: IJsonType[], download?: boolean) => {
-  const _zip = new JSZip();
-
-  const iconStreams = json.map((icon: IJsonType) => {
-    const iconStream: PassThrough & {
-      metadata?: { unicode: string[]; name: string };
-    } = new PassThrough();
-
-    const reader = new FileReader();
-
-    if (download) {
-      const svgs = _zip.folder('svg');
-      svgs?.file(`${icon.name}.svg`, icon.svgFile);
-    }
-
-    reader.onload = (e) => {
-      iconStream.write(e.target?.result);
-      iconStream.end();
-    };
-    reader.readAsText(icon.svgFile);
-
-    const unicode = Array.isArray(icon.unicode)
-      ? icon.unicode.map((curCodepoint) =>
-        String.fromCharCode(parseInt(curCodepoint.replace('u', '0x'), 16)),
-      )
-      : [String.fromCharCode(parseInt(icon.unicode.replace('u', '0x')))];
-
-    iconStream.metadata = {
-      unicode: [...unicode, ...icon.ligature],
-      name: icon.name,
-    };
-
-    return iconStream;
-  });
-
-  return {
-    iconStreams,
-    _zip,
-  };
-};
-
-const createSvgSymbol = (files: ISerializedSVG[]): string => {
-  const $ = load(
-    '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="0" height="0" style="display:none;"></svg>',
-    { xmlMode: true },
-  );
-  files.forEach((file: ISerializedSVG) => {
-    const svgNode = $(file.svg);
-    const symbolNode = $('<symbol></symbol>');
-    symbolNode.attr('viewBox', svgNode.attr('viewBox'));
-    symbolNode.attr('id', file.name);
-    symbolNode.append(svgNode.html());
-    $('svg').append(symbolNode);
-  });
-
-  return $.html('svg');
-};

--- a/shared/typings.ts
+++ b/shared/typings.ts
@@ -1,5 +1,4 @@
 import type { SVGIcons2SVGFontStreamOptions } from 'svgicons2svgfont';
-import { ReactNode } from 'react';
 
 export interface IJsonType {
   id: string;
@@ -8,12 +7,6 @@ export interface IJsonType {
   name: string;
   unicode: string[] | string;
   ligature?: string[] | string;
-}
-
-export interface ITabPanelProps {
-  children?: ReactNode;
-  index: number;
-  value: number;
 }
 
 export interface IIconInformation {

--- a/ui/components/App.tsx
+++ b/ui/components/App.tsx
@@ -30,24 +30,9 @@ import {
   IFormConfig,
   IFormGithub,
   IGeneratedFont,
-  ITabPanelProps,
 } from '../../shared/typings';
 
-const TabPanel = (props: ITabPanelProps): ReactElement => {
-  const { children, value, index, ...other } = props;
-
-  return (
-    <div
-      role="tabpanel"
-      hidden={value !== index}
-      id={`app-tabpanel-${index}`}
-      aria-labelledby={`simple-tab-${index}`}
-      {...other}
-    >
-      {value === index && <Box sx={{ p: 1 }}>{children}</Box>}
-    </div>
-  );
-};
+import TabPanel from './TabPanel/TabPanel';
 
 const App = (): ReactElement => {
   const [tabValue, setTabValue] = useState(0);

--- a/ui/components/TabPanel/TabPanel.tsx
+++ b/ui/components/TabPanel/TabPanel.tsx
@@ -1,0 +1,22 @@
+import Box from '@mui/material/Box';
+import { ReactElement, ReactNode } from 'react';
+
+interface TabPanelProps {
+  children?: ReactNode;
+  index: number;
+  value: number;
+}
+
+const TabPanel = ({ children, value, index, ...other }: TabPanelProps): ReactElement => (
+  <div
+    role="tabpanel"
+    hidden={value !== index}
+    id={`app-tabpanel-${index}`}
+    aria-labelledby={`app-tab-${index}`}
+    {...other}
+  >
+    {value === index && <Box sx={{ p: 1 }}>{children}</Box>}
+  </div>
+);
+
+export default TabPanel;


### PR DESCRIPTION
## Summary
- extract TabPanel to separate component for clarity
- move font helper functions to new module
- clean up imports in fonts logic
- remove unused typings

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_e_685ffb5c8dfc83258267454b9a83be34