### PR TITLE
feat: allow inverting fill rule

### DIFF
--- a/shared/fontHelpers.ts
+++ b/shared/fontHelpers.ts
@@ -80,6 +80,7 @@ export const iconConfigs = (files: ISerializedSVG[], hasLigatura: boolean) => {
       ligature,
       unicode: unicode ?? '',
       tags: file.tags,
+      inverted: file.inverted,
     });
   });
 
@@ -127,8 +128,8 @@ export const iconsStrems = (json: IJsonType[], download?: boolean) => {
 
     const unicode = Array.isArray(icon.unicode)
       ? icon.unicode.map((curCodepoint) =>
-          String.fromCharCode(parseInt(curCodepoint.replace('u', '0x'), 16)),
-        )
+        String.fromCharCode(parseInt(curCodepoint.replace('u', '0x'), 16)),
+      )
       : [String.fromCharCode(parseInt(icon.unicode.replace('u', '0x')))];
 
     iconStream.metadata = {

--- a/shared/invertFillRule.ts
+++ b/shared/invertFillRule.ts
@@ -1,0 +1,35 @@
+import SvgPath from 'svgpath';
+import SVGPathEditor from 'svg-path-reverse';
+
+const SvgPathWithReverse = SvgPath as unknown as {
+  prototype: {
+    reverse: (this: SvgPath) => SvgPath;
+  };
+};
+
+SvgPathWithReverse.prototype.reverse = function (this: SvgPath): SvgPath {
+  const reversed = SVGPathEditor.reverse(this.toString());
+  return SvgPath.from(reversed);
+};
+
+export const invertFillRule = (svg: string): string => {
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(svg, 'image/svg+xml');
+  const paths = Array.from(doc.getElementsByTagName('path'));
+  for (const path of paths) {
+    const d = path.getAttribute('d') ?? '';
+    path.setAttribute(
+      'd',
+      (
+        SvgPath(d) as unknown as SvgPath & {
+          reverse: () => SvgPath;
+        }
+      )
+        .reverse()
+        .toString(),
+    );
+  }
+  return new XMLSerializer().serializeToString(doc);
+};
+
+export default invertFillRule;

--- a/shared/invertFillRule.ts
+++ b/shared/invertFillRule.ts
@@ -9,7 +9,7 @@ const SvgPathWithReverse = SvgPath as unknown as {
 
 SvgPathWithReverse.prototype.reverse = function (this: SvgPath): SvgPath {
   const reversed = SVGPathEditor.reverse(this.toString());
-  return SvgPath.from(reversed);
+  return SvgPath(reversed);
 };
 
 export const invertFillRule = (svg: string): string => {

--- a/shared/typings.ts
+++ b/shared/typings.ts
@@ -8,6 +8,7 @@ export interface IJsonType {
   unicode: string[] | string;
   ligature?: string[] | string;
   tags?: string[];
+  inverted?: boolean;
 }
 
 export interface IIconInformation {
@@ -27,6 +28,7 @@ export interface ISerializedSVG {
   unicode?: string[] | string;
   ligature?: string[] | string;
   tags?: string[];
+  inverted?: boolean;
 }
 
 export interface IFormConfig {

--- a/ui/components/PreviewIcon/PreviewIcon.tsx
+++ b/ui/components/PreviewIcon/PreviewIcon.tsx
@@ -1,10 +1,11 @@
-import List from '@mui/material/List';
 import Card from '@mui/material/Card';
-import ListItem from '@mui/material/ListItem';
-import { Fragment, ReactElement, useState } from 'react';
-import TextField from '@mui/material/TextField';
+import List from '@mui/material/List';
 import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import ListItem from '@mui/material/ListItem';
+import TextField from '@mui/material/TextField';
 import ListItemText from '@mui/material/ListItemText';
+import { Fragment, ReactElement, useState } from 'react';
 import './PreviewIcon.scss';
 import { IGeneratedFont, IJsonType } from '../../../shared/typings';
 
@@ -14,10 +15,12 @@ const PreviewIcon = ({
   fontsFiles,
   ligatura,
   onChange,
+  onInvert,
 }: {
   fontsFiles: IGeneratedFont;
   ligatura: boolean;
   onChange: (id: string, data: Partial<IJsonType>) => void;
+  onInvert: (id: string) => void;
 }): ReactElement => {
   const [tagInputs, setTagInputs] = useState<Record<string, string>>({});
   if (!style) {
@@ -83,6 +86,13 @@ const PreviewIcon = ({
           });
         }}
       />
+      <Button
+        variant="outlined"
+        size="small"
+        onClick={() => onInvert(file.id)}
+      >
+        Invert Fill
+      </Button>
     </Stack>
   );
 


### PR DESCRIPTION
## Summary
- add `inverted` flag to icon types and font generation
- provide helper to reverse SVG path orientation
- add UI button to invert fill rule and ensure generation respects it

## Testing
- `npm test`
- `npx eslint shared/invertFillRule.ts shared/typings.ts shared/fontHelpers.ts ui/components/App.tsx ui/components/PreviewIcon/PreviewIcon.tsx`


------
https://chatgpt.com/codex/tasks/task_e_6897d71ef890832583ebdf988ee49021